### PR TITLE
fix: GearHeader rejects empty strings

### DIFF
--- a/web/components/gear/Header.js
+++ b/web/components/gear/Header.js
@@ -35,7 +35,11 @@ const GearHeader = ({ gearItem }) => {
 			} else {
 				setIsAdding(0)
 			}
-			if (category.length > 0 && manufacturer.length > 1 && model.length >= 2) {
+			if (
+				category.length > 0 &&
+				manufacturer.length >= 2 &&
+				model.length >= 2
+			) {
 				setIsAdding(2)
 				const timeout = setTimeout(() => {
 					addGearItem({
@@ -51,8 +55,8 @@ const GearHeader = ({ gearItem }) => {
 		} else {
 			if (
 				gearItem.category !== category ||
-				gearItem.model !== model ||
-				gearItem.manufacturer !== manufacturer
+				(gearItem.model !== model && model.length >= 2) ||
+				(gearItem.manufacturer !== manufacturer && manufacturer.length >= 2)
 			) {
 				const timeout = setTimeout(() => {
 					console.log('updating headers')


### PR DESCRIPTION
fixes an issue where empty model and manufacturer strings would result in the default allGearItems crashing when returning an array that contains a gearItem with empty model and manufacturer values